### PR TITLE
fix: add author email to package.json for Linux .deb builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,10 @@
     "pack": "electron-builder",
     "dist": "npm run build && electron-builder"
   },
-  "author": "Lume Team <team@lume.app>",
+  "author": {
+    "name": "Lume Team",
+    "email": "team@lume.app"
+  },
   "license": "MIT",
   "keywords": [
     "time tracking",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "pack": "electron-builder",
     "dist": "npm run build && electron-builder"
   },
-  "author": "Lume Team",
+  "author": "Lume Team <team@lume.app>",
   "license": "MIT",
   "keywords": [
     "time tracking",


### PR DESCRIPTION
Fixes GitHub Actions release workflow failure where Linux .deb package build requires author email for package maintainer field.

Error:
"Please specify author 'email' in the application package.json It is required to set Linux .deb package maintainer."

Changes:
- Updated author field from "Lume Team" to "Lume Team <team@lume.app>"
- This satisfies electron-builder's requirement for .deb packages
- Follows npm package.json author field specification

Resolves: Build & Release workflow failure for v1.0.0 tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project author information to include a contact email in metadata.
  * No changes to features, settings, or performance.
  * May appear in areas that display app metadata (e.g., About or package info).
  * No user action required; no downtime or migrations.
  * Builds and usage remain unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->