### PR TITLE
Normalize data handling and update tooling

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,10 +1,10 @@
-import js from '@eslint/js';
-import tsPlugin from '@typescript-eslint/eslint-plugin';
-import tsParser from '@typescript-eslint/parser';
-import reactPlugin from 'eslint-plugin-react';
-import reactHooksPlugin from 'eslint-plugin-react-hooks';
+const js = require('@eslint/js');
+const tsPlugin = require('@typescript-eslint/eslint-plugin');
+const tsParser = require('@typescript-eslint/parser');
+const reactPlugin = require('eslint-plugin-react');
+const reactHooksPlugin = require('eslint-plugin-react-hooks');
 
-export default [
+module.exports = [
   js.configs.recommended,
   {
     files: ['**/*.{ts,tsx,js,jsx}'],
@@ -14,42 +14,42 @@ export default [
         ecmaVersion: 'latest',
         sourceType: 'module',
         ecmaFeatures: {
-          jsx: true
-        }
+          jsx: true,
+        },
       },
       globals: {
         console: 'readonly',
         process: 'readonly',
         __dirname: 'readonly',
         Buffer: 'readonly',
-        NodeJS: 'readonly'
-      }
+        NodeJS: 'readonly',
+      },
     },
     plugins: {
       '@typescript-eslint': tsPlugin,
-      'react': reactPlugin,
-      'react-hooks': reactHooksPlugin
+      react: reactPlugin,
+      'react-hooks': reactHooksPlugin,
     },
     rules: {
       ...tsPlugin.configs.recommended.rules,
       '@typescript-eslint/no-unused-vars': ['error', {
         argsIgnorePattern: '^_',
         varsIgnorePattern: '^_',
-        caughtErrors: 'none'
+        caughtErrors: 'none',
       }],
       '@typescript-eslint/no-explicit-any': 'warn',
       'react-hooks/rules-of-hooks': 'error',
       'react-hooks/exhaustive-deps': 'warn',
       'no-console': 'off',
-      'no-undef': 'off' // TypeScript handles this
+      'no-undef': 'off', // TypeScript handles this
     },
     settings: {
       react: {
-        version: 'detect'
-      }
-    }
+        version: 'detect',
+      },
+    },
   },
   {
-    ignores: ['dist/', 'release/', 'node_modules/', '*.config.js', '*.config.ts']
-  }
+    ignores: ['dist/', 'release/', 'node_modules/', '*.config.js', '*.config.ts'],
+  },
 ];

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,7 +2,7 @@ module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'jsdom',
   setupFilesAfterEnv: ['<rootDir>/src/setupTests.ts'],
-  moduleNameMapping: {
+  moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
   },
   transform: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "jest-environment-jsdom": "^30.2.0",
         "postcss": "^8.5.6",
         "tailwindcss": "^4.1.14",
+        "ts-jest": "^29.4.4",
         "typescript": "^5.9.3",
         "vite": "^6.3.6",
         "wait-on": "^8.0.5"
@@ -6518,6 +6519,18 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/bs-logger": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
+      "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
+      "dev": true,
+      "dependencies": {
+        "fast-json-stable-stringify": "2.x"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/bser": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
@@ -9408,6 +9421,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/handlebars": {
+      "version": "4.7.8",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
+      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.2",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
+    },
     "node_modules/has-bigints": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
@@ -12069,6 +12103,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash.memoize": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
+      "dev": true
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -12178,6 +12218,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
     },
     "node_modules/make-fetch-happen": {
       "version": "10.2.1",
@@ -12620,6 +12666,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true
     },
     "node_modules/node-abi": {
       "version": "3.77.0",
@@ -15623,6 +15675,82 @@
         "typescript": ">=4.8.4"
       }
     },
+    "node_modules/ts-jest": {
+      "version": "29.4.4",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.4.tgz",
+      "integrity": "sha512-ccVcRABct5ZELCT5U0+DZwkXMCcOCLi2doHRrKy1nK/s7J7bch6TzJMsrY09WxgUUIP/ITfmcDS8D2yl63rnXw==",
+      "dev": true,
+      "dependencies": {
+        "bs-logger": "^0.2.6",
+        "fast-json-stable-stringify": "^2.1.0",
+        "handlebars": "^4.7.8",
+        "json5": "^2.2.3",
+        "lodash.memoize": "^4.1.2",
+        "make-error": "^1.3.6",
+        "semver": "^7.7.2",
+        "type-fest": "^4.41.0",
+        "yargs-parser": "^21.1.1"
+      },
+      "bin": {
+        "ts-jest": "cli.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": ">=7.0.0-beta.0 <8",
+        "@jest/transform": "^29.0.0 || ^30.0.0",
+        "@jest/types": "^29.0.0 || ^30.0.0",
+        "babel-jest": "^29.0.0 || ^30.0.0",
+        "jest": "^29.0.0 || ^30.0.0",
+        "jest-util": "^29.0.0 || ^30.0.0",
+        "typescript": ">=4.3 <6"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "@jest/transform": {
+          "optional": true
+        },
+        "@jest/types": {
+          "optional": true
+        },
+        "babel-jest": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jest-util": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-jest/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ts-jest/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -15769,6 +15897,19 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/uglify-js": {
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+      "dev": true,
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/unbox-primitive": {
@@ -16260,6 +16401,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "dev": true
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "jest-environment-jsdom": "^30.2.0",
     "postcss": "^8.5.6",
     "tailwindcss": "^4.1.14",
+    "ts-jest": "^29.4.4",
     "typescript": "^5.9.3",
     "vite": "^6.3.6",
     "wait-on": "^8.0.5"

--- a/src/components/TimeTracker.tsx
+++ b/src/components/TimeTracker.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { TimeEntry } from '../types';
+import { normalizeTimeEntries } from '../utils/normalizeData';
 
 const TimeTracker: React.FC = () => {
   const { t } = useTranslation();
@@ -35,7 +36,8 @@ const TimeTracker: React.FC = () => {
     try {
       if (window.electronAPI) {
         const entries = await window.electronAPI.getTimeEntries();
-        setRecentEntries(entries.slice(0, 10));
+        const normalized = normalizeTimeEntries(entries);
+        setRecentEntries(normalized.slice(0, 10));
       }
     } catch (error) {
       console.error('Failed to load recent entries:', error);

--- a/src/i18n/config.ts
+++ b/src/i18n/config.ts
@@ -14,10 +14,13 @@ export const resources = {
   },
 } as const;
 
-i18n
-  .use(LanguageDetector)
-  .use(initReactI18next)
-  .init({
+if (typeof window !== 'undefined') {
+  i18n.use(LanguageDetector);
+}
+
+i18n.use(initReactI18next);
+
+i18n.init({
     resources,
     fallbackLng: 'en',
     debug: process.env.NODE_ENV === 'development',

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -11,10 +11,15 @@ export interface TimeEntry {
 export interface AppUsage {
   id?: number;
   appName: string;
-  windowTitle: string;
+  windowTitle?: string;
+  category?: string;
+  domain?: string;
+  url?: string;
   startTime: string;
   endTime?: string;
   duration?: number;
+  isBrowser?: boolean;
+  isIdle?: boolean;
   createdAt?: string;
 }
 

--- a/src/utils/normalizeData.ts
+++ b/src/utils/normalizeData.ts
@@ -1,0 +1,126 @@
+import { TimeEntry, AppUsage } from '../types';
+
+const toOptionalNumber = (value: unknown): number | undefined => {
+  if (value == null) return undefined;
+
+  const rawNumber = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(rawNumber) ? rawNumber : undefined;
+};
+
+const toOptionalString = (value: unknown): string | undefined => {
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (trimmed.length > 0) {
+      return trimmed;
+    }
+  }
+  return undefined;
+};
+
+const pickString = (...values: unknown[]): string | undefined => {
+  for (const value of values) {
+    const stringValue = toOptionalString(value);
+    if (stringValue) return stringValue;
+  }
+  return undefined;
+};
+
+const toDateISO = (value: unknown): string | undefined => {
+  if (value == null) return undefined;
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (trimmed.length === 0) return undefined;
+    const parsed = new Date(trimmed);
+    return Number.isNaN(parsed.getTime()) ? undefined : parsed.toISOString();
+  }
+
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? undefined : value.toISOString();
+  }
+
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) return undefined;
+    const parsed = new Date(value);
+    return Number.isNaN(parsed.getTime()) ? undefined : parsed.toISOString();
+  }
+
+  return undefined;
+};
+
+export const normalizeTimeEntry = (raw: any): TimeEntry | null => {
+  if (!raw) return null;
+
+  const startTime = toDateISO(raw.startTime) ?? toDateISO(raw.start_time) ?? toDateISO(raw.start_date);
+  if (!startTime) return null;
+  const endTime = toDateISO(raw.endTime) ?? toDateISO(raw.end_time) ?? undefined;
+  let durationMinutes = toOptionalNumber(raw.duration ?? raw.durationMinutes ?? raw.duration_minutes);
+
+  if ((durationMinutes == null || Number.isNaN(durationMinutes)) && endTime) {
+    const start = new Date(startTime).getTime();
+    const end = new Date(endTime).getTime();
+    if (Number.isFinite(start) && Number.isFinite(end) && end > start) {
+      durationMinutes = Math.max(1, Math.round((end - start) / 60000));
+    }
+  }
+
+  return {
+    id: raw.id ?? raw.entryId ?? undefined,
+    task: pickString(raw.task, raw.taskName, raw.title) || 'Untitled Task',
+    startTime,
+    endTime,
+    duration: durationMinutes ?? undefined,
+    category: pickString(raw.category, raw.categoryName, raw.category_name),
+    createdAt: pickString(raw.createdAt, raw.created_at),
+  };
+};
+
+export const normalizeAppUsage = (raw: any): AppUsage | null => {
+  if (!raw) return null;
+
+  const startTime = toDateISO(raw.startTime) ?? toDateISO(raw.start_time);
+  if (!startTime) return null;
+  const endTime = toDateISO(raw.endTime) ?? toDateISO(raw.end_time) ?? undefined;
+  let durationSeconds = toOptionalNumber(raw.duration);
+
+  if ((durationSeconds == null || Number.isNaN(durationSeconds)) && endTime) {
+    const start = new Date(startTime).getTime();
+    const end = new Date(endTime).getTime();
+    if (Number.isFinite(start) && Number.isFinite(end) && end > start) {
+      durationSeconds = Math.max(1, Math.round((end - start) / 1000));
+    }
+  }
+
+  return {
+    id: raw.id ?? raw.usageId ?? undefined,
+    appName: pickString(raw.appName, raw.app_name, raw.name) || 'Unknown',
+    windowTitle: pickString(raw.windowTitle, raw.window_title),
+    category: pickString(raw.category, raw.category_name),
+    domain: pickString(raw.domain),
+    url: pickString(raw.url),
+    startTime,
+    endTime,
+    duration: durationSeconds ?? undefined,
+    isBrowser: typeof raw.isBrowser === 'boolean'
+      ? raw.isBrowser
+      : raw.is_browser != null
+        ? Boolean(raw.is_browser)
+        : undefined,
+    isIdle: typeof raw.isIdle === 'boolean'
+      ? raw.isIdle
+      : raw.is_idle != null
+        ? Boolean(raw.is_idle)
+        : undefined,
+    createdAt: pickString(raw.createdAt, raw.created_at),
+  };
+};
+
+export const normalizeTimeEntries = (rawEntries: any[]): TimeEntry[] =>
+  (rawEntries || [])
+    .map(normalizeTimeEntry)
+    .filter((entry): entry is TimeEntry => entry !== null);
+
+export const normalizeAppUsageList = (rawUsage: any[]): AppUsage[] =>
+  (rawUsage || [])
+    .map(normalizeAppUsage)
+    .filter((usage): usage is AppUsage => usage !== null);

--- a/src/utils/normalizeData.ts
+++ b/src/utils/normalizeData.ts
@@ -101,16 +101,30 @@ export const normalizeAppUsage = (raw: any): AppUsage | null => {
     startTime,
     endTime,
     duration: durationSeconds ?? undefined,
-    isBrowser: typeof raw.isBrowser === 'boolean'
-      ? raw.isBrowser
-      : raw.is_browser != null
-        ? Boolean(raw.is_browser)
-        : undefined,
-    isIdle: typeof raw.isIdle === 'boolean'
-      ? raw.isIdle
-      : raw.is_idle != null
-        ? Boolean(raw.is_idle)
-        : undefined,
+    isBrowser:
+      typeof raw.isBrowser === 'boolean'
+        ? raw.isBrowser
+        : typeof raw.isBrowser === 'number'
+          ? Boolean(raw.isBrowser)
+          : typeof raw.is_browser === 'boolean'
+            ? raw.is_browser
+            : typeof raw.is_browser === 'number'
+              ? Boolean(raw.is_browser)
+              : raw.is_browser != null
+                ? Boolean(raw.is_browser)
+                : undefined,
+    isIdle:
+      typeof raw.isIdle === 'boolean'
+        ? raw.isIdle
+        : typeof raw.isIdle === 'number'
+          ? Boolean(raw.isIdle)
+          : typeof raw.is_idle === 'boolean'
+            ? raw.is_idle
+            : typeof raw.is_idle === 'number'
+              ? Boolean(raw.is_idle)
+              : raw.is_idle != null
+                ? Boolean(raw.is_idle)
+                : undefined,
     createdAt: pickString(raw.createdAt, raw.created_at),
   };
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,8 @@
     "module": "ESNext",
     "skipLibCheck": true,
     "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
     "allowImportingTsExtensions": true,
     "resolveJsonModule": true,
     "isolatedModules": true,


### PR DESCRIPTION
## Summary by Sourcery

Normalize and standardize data handling by adding dedicated mapping and normalization functions, refactor database and UI components to use those utilities and compute durations robustly, and update tooling configurations for ESLint, Jest, and TypeScript interoperability.

New Features:
- Introduce normalization utilities to standardize TimeEntry and AppUsage objects
- Expose a mockable execAsync in ActivityMonitor to enable controlled command execution during tests

Enhancements:
- Refactor DatabaseManager to map raw rows into typed entries with computed durations and normalized field names
- Update Dashboard, Reports, and TimeTracker components to apply normalization, improve date filtering, and handle duration and active task calculations more reliably
- Enhance AppUsage type with optional metadata fields (category, domain, url, isBrowser, isIdle) and adjust typings in types/index.ts
- Adjust i18n initialization to conditionally use LanguageDetector in browser environments

Build:
- Add esModuleInterop and allowSyntheticDefaultImports to tsconfig
- Include ts-jest as a development dependency in package.json

CI:
- Rename moduleNameMapping to moduleNameMapper in jest.config.js

Chores:
- Convert ESLint config to CommonJS, standardize plugin imports and formatting
- Update eslint.config to use module.exports and add trailing commas

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - More accurate “Today” stats and reports using normalized data and local-time calculations.
  - Improved active task detection and safer handling of missing/invalid durations.
  - Reliable loading state cleanup and more robust i18n initialization in non-browser environments.

- Tests
  - Enhanced testability of system command execution for activity monitoring.

- Chores
  - Updated Jest configuration and added TypeScript support via ts-jest.
  - Adjusted TypeScript interop settings.
  - Standardized lint configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->